### PR TITLE
Minor bug fixes in UI

### DIFF
--- a/client/src/components/LocaleSwitcher.tsx
+++ b/client/src/components/LocaleSwitcher.tsx
@@ -30,7 +30,7 @@ export default function LocaleSwitcher() {
 
         <ul
           tabIndex={0}
-          className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-200 rounded-box w-52 text-gray-900"
+          className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-200 rounded-box w-52 text-white-900"
         >
           {Object.entries(supportedLngs).map(([code, name]) => (
             <>

--- a/client/src/partials/Publications.tsx
+++ b/client/src/partials/Publications.tsx
@@ -22,7 +22,7 @@ function Publications() {
       venue:
         t("publications.publication2"),
       year: "2014",
-      link: "https://arxiv.org/abs/2101.00100",
+      link: "https://www.jstor.org/stable/10.1086/678271",
     },
     {
       title: t("publications.journal3"),
@@ -30,7 +30,7 @@ function Publications() {
       authors: "Watts, Duncan",
       venue: "Crown, 2011, ISBN: 9780385531696, 0385531699.",
       year: "2011",
-      link: "https://arxiv.org/abs/2101.00100",
+      link: "https://www.google.com/books/edition/Everything_Is_Obvious/kT_4AAAAQBAJ?hl=en&gbpv=0",
     },
   ];
 


### PR DESCRIPTION
## Description
This is a small PR that introduces two bug fixes. For the first bug, the second and third links in the research publications section direct to the same URL. I corrected it to direct to their respective papers, which I was able to find here: https://css.seas.upenn.edu/project/common-sense/. For the second bug, the font color of unselected languages in the language dropdown is hard to read due to insufficient contrast with the background. I modified the CSS of the dropdown component so the unselected languages are easily readable.

## Changes 
- Publications.tsx: Removed the second link in the publications list and replaced it with https://www.jstor.org/stable/10.1086/678271. Removed the third link and replaced it with https://www.google.com/books/edition/Everything_Is_Obvious/kT_4AAAAQBAJ?hl=en&gbpv=0.
- LocaleSwitcher.tsx: Changed the text color to white instead of gray to provide easier contrast with the background and ultimately improve user experience reading the language options.