### PR TITLE
165 Filter statements by createAt() and also fix toggling multiple answers not updating properly

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -121,7 +121,7 @@ const Dashboard: React.FC = () => {
   // For I_agree: handleCheckboxChange(id, 'I_agree')
   // For others_agree: handleCheckboxChange(id, 'others_agree')
   const handleCheckboxChange = async (id: number, type: 'I_agree' | 'others_agree') => {
-    const stateKey = type === 'I_agree' ? 'agreeCheckboxStates' : 'checkboxStates';
+    const stateKey = type === 'I_agree' ? 'agreeCheckboxStates' : 'othersAgreeCheckboxStates';
     const setState = type === 'I_agree' ? setAgreeCheckboxStates : setOthersAgreeCheckboxStates;
     const newCheckedState = !((type === 'I_agree' ? agreeCheckboxStates : othersAgreeCheckboxStates)[id]);
     const currentAnswer = answerList.find(answer => answer.id === id);
@@ -147,7 +147,12 @@ const Dashboard: React.FC = () => {
         perceived_commonsense: 0,
         sessionId: surveySession,
       });
-      console.error(`${type} updated`, response.data);
+      console.log(`${type} updated`, response.data);
+      if (type == 'I_agree') {
+        currentAnswer.I_agree = newCheckedState;
+      } else {
+        currentAnswer.others_agree = newCheckedState;
+      }
     } catch (error) {
       console.error(`Error updating ${type}`, error);
       // Revert the state change in case of an error

--- a/server/controllers/emails.js
+++ b/server/controllers/emails.js
@@ -14,20 +14,9 @@ const ses = new aws.SES({
   },
 });
 
-// create Nodemailer SES transporter
-// let transporter = nodemailer.createTransport({
-//   SES: { ses, aws },
-// });
-
-const transporter = nodemailer.createTransport({
-  service: "Gmail",
-  host: "smtp.gmail.com",
-  port: 465,
-  secure: true,
-  auth: {
-    user: process.env.NODEMAILER_EMAIL,
-    pass: process.env.NODEMAILER_PASSWORD,
-  },
+//create Nodemailer SES transporter
+let transporter = nodemailer.createTransport({
+  SES: { ses, aws },
 });
 
 const URL =

--- a/server/controllers/emails.js
+++ b/server/controllers/emails.js
@@ -15,8 +15,19 @@ const ses = new aws.SES({
 });
 
 // create Nodemailer SES transporter
-let transporter = nodemailer.createTransport({
-  SES: { ses, aws },
+// let transporter = nodemailer.createTransport({
+//   SES: { ses, aws },
+// });
+
+const transporter = nodemailer.createTransport({
+  service: "Gmail",
+  host: "smtp.gmail.com",
+  port: 465,
+  secure: true,
+  auth: {
+    user: process.env.NODEMAILER_EMAIL,
+    pass: process.env.NODEMAILER_PASSWORD,
+  },
 });
 
 const URL =

--- a/server/routes/answers.js
+++ b/server/routes/answers.js
@@ -117,7 +117,13 @@ router.post(
                       i = 0;
                       while (i < result.length) {
                         if (item.statementId == result[i].statementId) {
-                          if (item.id < result[i].id) {
+                          // if (item.id < result[i].id) {
+                          //   return false;
+                          // }
+                          if (
+                            new Date(item.createdAt).getTime() <
+                            new Date(result[i].createdAt).getTime()
+                          ) {
                             return false;
                           }
                         }

--- a/server/routes/answers.js
+++ b/server/routes/answers.js
@@ -117,9 +117,6 @@ router.post(
                       i = 0;
                       while (i < result.length) {
                         if (item.statementId == result[i].statementId) {
-                          // if (item.id < result[i].id) {
-                          //   return false;
-                          // }
                           if (
                             new Date(item.createdAt).getTime() <
                             new Date(result[i].createdAt).getTime()

--- a/server/routes/results.js
+++ b/server/routes/results.js
@@ -189,6 +189,12 @@ const calculateAgreementPercentage = async (statementIds) => {
           if (item.id < answersForOneStatement[i].id) {
             return false;
           }
+          // if (
+          //   new Date(item.createdAt).getTime() <
+          //   new Date(answersForOneStatement[i].createdAt).getTime()
+          // ) {
+          //   return false;
+          // }
         }
         i++;
       }

--- a/server/routes/results.js
+++ b/server/routes/results.js
@@ -192,9 +192,6 @@ const calculateAgreementPercentage = async (statementIds) => {
       i = 0;
       while (i < answersForOneStatement.length) {
         if (item.sessionId == answersForOneStatement[i].sessionId) {
-          // if (item.id < answersForOneStatement[i].id) {
-          //   return false;
-          // }
           if (
             new Date(item.createdAt).getTime() <
             new Date(answersForOneStatement[i].createdAt).getTime()


### PR DESCRIPTION
**165 Filter statements by createAt() and also fix toggling multiple answers not updating properly**
This closes issue #165 that I added, which also explains this PR pretty well but here are the things that I did:

1. Fixed bug where if users toggle multiple answers at once across `I_agree` and `others_agree`, only one of the columns updates. This was due to a setState error in my code, so I fixed it by changing `currentAnswer` to update its value for I_agree and others_agree accordingly before sending data to the database
1. Changed the filtering for `/getanswers` and `/getAgreementPercentage` to filter based on `createAt()` instead of `id`, which is better practice
2. Bug that I noticed: if users toggle answers faster than 1 second, then a duplicate of that statement appears in the list of statements. This is because we are now filtering by `createAt()`, which only records up to the second (an example is `2024-07-19 08:11:03`). So if a user clicks multiple times in one second, the createAt() time is the same for both entries so both entries are displayed. I think to fix this, we could add milliseconds to `createAt()` or filter based on a different way -- will ask Mark about this
![Pasted Graphic](https://github.com/user-attachments/assets/b8240939-26c3-4765-814c-b5d5784fbf07)
